### PR TITLE
Update UIFont+IBCustomFonts.m

### DIFF
--- a/UIFont+IBCustomFonts.m
+++ b/UIFont+IBCustomFonts.m
@@ -53,7 +53,10 @@ static NSDictionary *iBCustomFontsDict;
 +(UIFont*)new_fontWithName:(NSString*)fontName size:(CGFloat)fontSize traits:(int)traits {
 	return [self new_fontWithName:[iBCustomFontsDict objectForKey:fontName] ?: fontName size:fontSize traits:traits];
 }
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
 +(UIFont*)new_fontWithDescriptor:(UIFontDescriptor*)descriptor size:(CGFloat)fontSize {
     return [self new_fontWithDescriptor:[UIFontDescriptor fontDescriptorWithName:[iBCustomFontsDict objectForKey:[descriptor.fontAttributes objectForKey:UIFontDescriptorNameAttribute]] ?: [descriptor.fontAttributes objectForKey:UIFontDescriptorNameAttribute] size:fontSize] size:fontSize];
 }
+#endif
 @end


### PR DESCRIPTION
Hide fontWithDescriptor:size from SDKs < 7.0.

This will allow this code to compile on XCode < 5.0 for late adopters / legacy applications.
