### PR TITLE
switch to +initialize from +load; use standard_swizzle() for swizzling

### DIFF
--- a/UIFont+IBCustomFonts.m
+++ b/UIFont+IBCustomFonts.m
@@ -61,7 +61,7 @@ static NSDictionary *iBCustomFontsDict;
     if (self == [UIFont class]) {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
-            iBCustomFontsDict = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IBCustomFonts"];
+            iBCustomFontsDict = [[NSBundle mainBundle] objectForInfoDictionaryKey:IBCustomFontsKey];
             NSArray *methods = @[@"fontWithName:size:", @"fontWithName:size:traits:", @"fontWithDescriptor:size:"];
             for (NSString* methodName in methods) {
                 standard_swizzle(self, NSSelectorFromString(methodName), NSSelectorFromString([NSString stringWithFormat:@"new_%@", methodName]));


### PR DESCRIPTION
1.  +initialize provides the runtime improvement of not necessarily
   being front loaded; generally with objective c the later the binding
   the better.
2.  Use dispatch_once to guarantee the methods are only swizzled once
   (weird things might happen if the project has a UIFont subclass).
3.  standard_swizzle() is practically ubiquitous at this point, no need
   to reinvent the wheel
4.  Also I put the bundle key in a const string in case the key may
   later conflict with something else (plus it’s better to expose the
   variable name than the actual string)
