### PR TITLE
Added NSString cast to IBCustomFontsKey to remove warning

### DIFF
--- a/IBCustomFonts.xcodeproj/xcuserdata/adolforodriguez.xcuserdatad/xcschemes/IBCustomFonts.xcscheme
+++ b/IBCustomFonts.xcodeproj/xcuserdata/adolforodriguez.xcuserdatad/xcschemes/IBCustomFonts.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "56E9F05A17F0BD4B009D7CAD"
+               BuildableName = "IBCustomFonts.app"
+               BlueprintName = "IBCustomFonts"
+               ReferencedContainer = "container:IBCustomFonts.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "56E9F07E17F0BD4B009D7CAD"
+               BuildableName = "IBCustomFontsTests.xctest"
+               BlueprintName = "IBCustomFontsTests"
+               ReferencedContainer = "container:IBCustomFonts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "56E9F05A17F0BD4B009D7CAD"
+            BuildableName = "IBCustomFonts.app"
+            BlueprintName = "IBCustomFonts"
+            ReferencedContainer = "container:IBCustomFonts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "56E9F05A17F0BD4B009D7CAD"
+            BuildableName = "IBCustomFonts.app"
+            BlueprintName = "IBCustomFonts"
+            ReferencedContainer = "container:IBCustomFonts.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "56E9F05A17F0BD4B009D7CAD"
+            BuildableName = "IBCustomFonts.app"
+            BlueprintName = "IBCustomFonts"
+            ReferencedContainer = "container:IBCustomFonts.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/IBCustomFonts.xcodeproj/xcuserdata/adolforodriguez.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/IBCustomFonts.xcodeproj/xcuserdata/adolforodriguez.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>IBCustomFonts.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>56E9F05A17F0BD4B009D7CAD</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>56E9F07E17F0BD4B009D7CAD</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/UIFont+IBCustomFonts.m
+++ b/UIFont+IBCustomFonts.m
@@ -61,7 +61,7 @@ static NSDictionary *iBCustomFontsDict;
     if (self == [UIFont class]) {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
-            iBCustomFontsDict = [[NSBundle mainBundle] objectForInfoDictionaryKey:IBCustomFontsKey];
+            iBCustomFontsDict = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString*)IBCustomFontsKey];
             NSArray *methods = @[@"fontWithName:size:", @"fontWithName:size:traits:", @"fontWithDescriptor:size:"];
             for (NSString* methodName in methods) {
                 standard_swizzle(self, NSSelectorFromString(methodName), NSSelectorFromString([NSString stringWithFormat:@"new_%@", methodName]));


### PR DESCRIPTION
I added an NSString\* cast to prevent the warning:
Sending 'const NSString *__strong' to parameter of type 'NSString *' discards qualifiers

Please ignore xuserdatad files.
